### PR TITLE
Initial configuration for terraform/main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,32 +12,8 @@ data "hcp_packer_image" "loki" {
   region          = "us-east-2"
 }
 
-data "hcp_packer_image_iteration" "hashicups" {
-  bucket_name  = var.hcp_bucket_hashicups
-  channel = var.hcp_channel
-}
-
-data "hcp_packer_image" "hashicups_west" {
-  bucket_name    = var.hcp_bucket_hashicups
-  cloud_provider = "aws"
-  iteration_id   = data.hcp_packer_image_iteration.hashicups.id
-  region         = "us-west-2"
-}
-
-data "hcp_packer_image" "hashicups_east" {
-  bucket_name    = var.hcp_bucket_hashicups
-  cloud_provider = "aws"
-  iteration_id   = data.hcp_packer_image_iteration.hashicups.id
-  region         = "us-east-2"
-}
-
 provider "aws" {
   region = var.region_east
-}
-
-provider "aws" {
-  alias  = "west"
-  region = var.region_west
 }
 
 resource "aws_instance" "loki" {
@@ -55,48 +31,3 @@ resource "aws_instance" "loki" {
     Name = "Learn-Packer-LokiGrafana"
   }
 }
-
-/*
-resource "aws_instance" "hashicups_east" {
-  ami           = data.hcp_packer_image.hashicups_east.id
-  instance_type = "t2.micro"
-  subnet_id     = aws_subnet.subnet_public_east.id
-  vpc_security_group_ids = [
-    aws_security_group.ssh_east.id,
-    aws_security_group.allow_egress_east.id,
-    aws_security_group.promtail_east.id,
-    aws_security_group.hashicups_east.id,
-  ]
-  associate_public_ip_address = true
-
-  tags = {
-    Name = "Learn-Packer-HashiCups"
-  }
-
-  depends_on = [
-    aws_instance.loki
-  ]
-}
-
-resource "aws_instance" "hashicups_west" {
-  provider      = aws.west
-  ami           = data.hcp_packer_image.hashicups_west.id
-  instance_type = "t2.micro"
-  subnet_id     = aws_subnet.subnet_public_west.id
-  vpc_security_group_ids = [
-    aws_security_group.ssh_west.id,
-    aws_security_group.allow_egress_west.id,
-    aws_security_group.promtail_west.id,
-    aws_security_group.hashicups_west.id,
-  ]
-  associate_public_ip_address = true
-
-  tags = {
-    Name = "Learn-Packer-HashiCups"
-  }
-
-  depends_on = [
-    aws_instance.loki
-  ]
-}
-*/


### PR DESCRIPTION
Hey @tunzor, I think this should be the initial configuration for Terraform.

This does a couple things:
- Removes the HashiCups HCP Packer blocks -- this is because on the first Terraform run, the HashiCups images will not be in HCP Packer yet
- Removes the second `aws` provider alias and remove the comments. Loki is deployed to `us-east-1` so we only need the single `aws` provider initially. When we tell users to deploy HashiCups, we can tell users to add the second alias-ed `aws` provider and the HashiCups EC2 instances.

Please let me know your thoughts and if this makes sense. Thanks!