### PR TITLE
removing cloud block until a later date

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,16 +6,8 @@ terraform {
       version = "~> 3.0"
     }
     hcp = {
-      source = "hashicorp/hcp"
+      source  = "hashicorp/hcp"
       version = "0.17.0"
-    }
-  }
-
-cloud {
-    hostname     = "app.terraform.io"
-
-    workspaces {
-      name = "learn-hcp-packer-golden-image"
     }
   }
 }


### PR DESCRIPTION
I accidentally pushed to main before the accompanying tutorial was live.